### PR TITLE
Release/v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## v1.0 (2105 Jul 18)
+
+- Added support for .env file format
+- Added support for YAML dictionary format
+- Added support for JSON dictionary format (handled by YAML parser)
+- Initial Release

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -28,7 +28,17 @@
     ]]></description>
 
   <change-notes><![CDATA[
+      <a href="https://github.com/Ashald/EnvFile/tree/v1.0"><b>v1.0</b></a> (2015 Jul 18)
+      <br/>
+      <br/>
 
+      <b>Major Changes</b>:
+      <ul>
+        <li>Added support for .env file format</li>
+        <li>Added support for YAML dictionary format</li>
+        <li>Added support for JSON dictionary format (handled by YAML parser)</li>
+        <li>Initial Release</li>
+      </ul>
     ]]>
   </change-notes>
 

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>net.ashald.envfile</id>
   <name>Env File</name>
-  <version>dev</version>
+  <version>1.0</version>
   <vendor email="envfile@ashald.net">Borys Pierov</vendor>
 
   <description><![CDATA[


### PR DESCRIPTION
Backport `v1.0` release changes into `develop`