### PR TITLE
Strip `export ` lines to make it `shell` compatible

### DIFF
--- a/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
+++ b/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
@@ -28,6 +28,8 @@ public class DotEnvFileParser extends AbstractEnvVarsProvider {
             List<String> lines = Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8);
             for (String l: lines) {
                 String strippedLine = l.trim();
+                // remove `export` at the beginning of the line if a variable follows
+                strippedLine = strippedLine.replaceAll("^\\s*export\\s+(?=\\w)", "");
                 if (!strippedLine.startsWith("#") && strippedLine.contains("=")) {
                     String[] tokens = strippedLine.split("=", 2);
                     String key = tokens[0];


### PR DESCRIPTION
fixes #102

The lookahead `(?=\\w)`ensures that the pathological case of a variable called `export` is not accidentally destroyed: `export = foo` is not changed by the regex, but `export foo=bar` becomes `foo=bar`.