### PR TITLE
Use parent environment to allow variable substitution

### DIFF
--- a/modules/platform/src/main/java/net/ashald/envfile/platform/EnvUtil.java
+++ b/modules/platform/src/main/java/net/ashald/envfile/platform/EnvUtil.java
@@ -1,0 +1,33 @@
+package net.ashald.envfile.platform;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.FileUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class EnvUtil {
+    /**
+     * Mirrors {@link GeneralCommandLine#getEffectiveEnvironment()} without adding the overrides set for the command line.
+     * This basically is the parent environment (if it's enabled) and PWD set to the working directory of the command line.
+     *
+     * @return A new map with the effective environment
+     */
+    public static Map<String, String> getInitialEnv(@NotNull GeneralCommandLine cmdline) {
+        Map<String, String> environment = new HashMap<>();
+        if (cmdline.getParentEnvironmentType() != GeneralCommandLine.ParentEnvironmentType.NONE) {
+            environment.putAll(cmdline.getParentEnvironment());
+        }
+
+        if (SystemInfo.isUnix) {
+            File workDirectory = cmdline.getWorkDirectory();
+            if (workDirectory != null) {
+                environment.put("PWD", FileUtil.toSystemDependentName(workDirectory.getAbsolutePath()));
+            }
+        }
+        return environment;
+    }
+}

--- a/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
+++ b/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
@@ -25,7 +25,8 @@ public class GolandRunConfigurationExtension extends GoRunConfigurationExtension
     @Override
     protected void patchCommandLine(@NotNull GoRunConfigurationBase<?> goRunConfigurationBase, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine generalCommandLine, @NotNull String s) throws ExecutionException {
         Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(goRunConfigurationBase, EnvUtil.getInitialEnv(generalCommandLine));
-        Map<String, String> currentEnv = generalCommandLine.getEffectiveEnvironment();
+        // currentEnv is the reference used by generalCommandLine, not a copy
+        Map<String, String> currentEnv = generalCommandLine.getEnvironment();
         currentEnv.clear();
         currentEnv.putAll(newEnv);
     }

--- a/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
+++ b/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
@@ -6,12 +6,12 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.openapi.options.SettingsEditor;
+import net.ashald.envfile.platform.EnvUtil;
 import net.ashald.envfile.platform.ui.EnvFileConfigurationEditor;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class GolandRunConfigurationExtension extends GoRunConfigurationExtension {
@@ -24,8 +24,8 @@ public class GolandRunConfigurationExtension extends GoRunConfigurationExtension
 
     @Override
     protected void patchCommandLine(@NotNull GoRunConfigurationBase<?> goRunConfigurationBase, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine generalCommandLine, @NotNull String s) throws ExecutionException {
-        Map<String, String> currentEnv = generalCommandLine.getEnvironment();
-        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(goRunConfigurationBase, new HashMap<>(currentEnv));
+        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(goRunConfigurationBase, EnvUtil.getInitialEnv(generalCommandLine));
+        Map<String, String> currentEnv = generalCommandLine.getEffectiveEnvironment();
         currentEnv.clear();
         currentEnv.putAll(newEnv);
     }

--- a/modules/products/pycharm/src/main/java/net/ashald/envfile/products/pycharm/PyCharmRunConfigurationExtension.java
+++ b/modules/products/pycharm/src/main/java/net/ashald/envfile/products/pycharm/PyCharmRunConfigurationExtension.java
@@ -8,12 +8,12 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import com.jetbrains.python.run.AbstractPythonRunConfiguration;
 import com.jetbrains.python.run.PythonRunConfigurationExtension;
+import net.ashald.envfile.platform.EnvUtil;
 import net.ashald.envfile.platform.ui.EnvFileConfigurationEditor;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class PyCharmRunConfigurationExtension extends PythonRunConfigurationExtension {
@@ -53,8 +53,8 @@ public class PyCharmRunConfigurationExtension extends PythonRunConfigurationExte
 
     @Override
     protected void patchCommandLine(@NotNull AbstractPythonRunConfiguration configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
+        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, EnvUtil.getInitialEnv(cmdLine));
         Map<String, String> currentEnv = cmdLine.getEnvironment();
-        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, new HashMap<>(currentEnv));
         currentEnv.clear();
         currentEnv.putAll(newEnv);
     }

--- a/modules/products/pycharm/src/main/java/net/ashald/envfile/products/pycharm/PyCharmRunConfigurationExtension.java
+++ b/modules/products/pycharm/src/main/java/net/ashald/envfile/products/pycharm/PyCharmRunConfigurationExtension.java
@@ -54,6 +54,7 @@ public class PyCharmRunConfigurationExtension extends PythonRunConfigurationExte
     @Override
     protected void patchCommandLine(@NotNull AbstractPythonRunConfiguration configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
         Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, EnvUtil.getInitialEnv(cmdLine));
+        // currentEnv is the reference used by generalCommandLine, not a copy
         Map<String, String> currentEnv = cmdLine.getEnvironment();
         currentEnv.clear();
         currentEnv.putAll(newEnv);

--- a/modules/products/rubymine/src/main/java/net/ashald/envfile/products/rubymine/RubyMineRunConfigurationExtension.java
+++ b/modules/products/rubymine/src/main/java/net/ashald/envfile/products/rubymine/RubyMineRunConfigurationExtension.java
@@ -54,6 +54,7 @@ public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExten
     @Override
     protected void patchCommandLine(@NotNull AbstractRubyRunConfiguration<?> configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
         Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, EnvUtil.getInitialEnv(cmdLine));
+        // currentEnv is the reference used by generalCommandLine, not a copy
         Map<String, String> currentEnv = cmdLine.getEnvironment();
         currentEnv.clear();
         currentEnv.putAll(newEnv);

--- a/modules/products/rubymine/src/main/java/net/ashald/envfile/products/rubymine/RubyMineRunConfigurationExtension.java
+++ b/modules/products/rubymine/src/main/java/net/ashald/envfile/products/rubymine/RubyMineRunConfigurationExtension.java
@@ -6,6 +6,7 @@ import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
+import net.ashald.envfile.platform.EnvUtil;
 import net.ashald.envfile.platform.ui.EnvFileConfigurationEditor;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration;
 import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExtension {
@@ -53,8 +53,8 @@ public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExten
 
     @Override
     protected void patchCommandLine(@NotNull AbstractRubyRunConfiguration<?> configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
+        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, EnvUtil.getInitialEnv(cmdLine));
         Map<String, String> currentEnv = cmdLine.getEnvironment();
-        Map<String, String> newEnv = EnvFileConfigurationEditor.collectEnv(configuration, new HashMap<>(currentEnv));
         currentEnv.clear();
         currentEnv.putAll(newEnv);
     }


### PR DESCRIPTION
I'm experimenting to support EnvFile with [BashSupport Pro}(https://www.bashsupport.com).
I noticed that the variable substitution isn't working as it should.

Currently EnvFile only provides the variables configured directly in the run configuration to the var env providers.
Now, if a variable substitution references a variable, which is inherited from the parent environment, then it has an empty value. That's happening because `eneralCommandLine.getEnvironment()` is not including the variables from the parent environment.

The SDK's process setup adds the parent environment variables to the new process, if the setting for this is enabled: https://github.com/JetBrains/intellij-community/blob/8e89a51b18059a34081c84439c6c19483f64ad10/platform/platform-util-io/src/com/intellij/execution/configurations/GeneralCommandLine.java#L469

EnvFile must follow the same logic to provide the same set of variables to the patched command line.
I successfully tested this with Python, the other modified providers follow the same logic.

I don't know much about `EnvFile`, but hope that this is helpful.