### PR TITLE
updated common-text to use latest version (Crit Vuln resolution)

### DIFF
--- a/modules/platform/build.gradle
+++ b/modules/platform/build.gradle
@@ -11,7 +11,7 @@ buildSearchableOptions.enabled = false
 dependencies {
     implementation project(":envfile-core")
     implementation 'org.jetbrains:annotations:23.0.0'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'


### PR DESCRIPTION
Previous version of commons-lang, 1.9 contains this vulnerability:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889
Which has now been patched in commons-lang 1.10.0

Simple Pull request to update the dependency