### PR TITLE
Add support for escaped double quotes

### DIFF
--- a/modules/core/src/test/java/net/ashald/envfile/providers/dotenv/DotEnvFileParserTest.java
+++ b/modules/core/src/test/java/net/ashald/envfile/providers/dotenv/DotEnvFileParserTest.java
@@ -124,4 +124,21 @@ public class DotEnvFileParserTest {
                 result
         );
     }
+
+    @Test
+    public void GIVEN_parse_WHEN_multilineVariableWithLineBreaksAndQuotes_THEN_preserved() {
+        val result = PARSER.parse(
+                getFile("multi-line-variable-with-line-breaks-and-quotes.env")
+        );
+
+        assertEquals(
+                ImmutableMap.of(
+                        "JSON", "{\n" +
+                                "\"foo\": \"bar\",\n" +
+                                "\"fizz\": \"fuzz\"\n" +
+                                "}"
+                ),
+                result
+        );
+    }
 }

--- a/modules/core/src/test/resources/providers/dotenv/multi-line-variable-with-line-breaks-and-quotes.env
+++ b/modules/core/src/test/resources/providers/dotenv/multi-line-variable-with-line-breaks-and-quotes.env
@@ -1,0 +1,4 @@
+JSON="{
+  \"foo\": \"bar\",
+  \"fizz\": \"fuzz\"
+}"


### PR DESCRIPTION
The way the double quote detection was implemented would match on escaped double quotes as well. This leads to partial values in the environment variables.

The goal of this PR is to ignore the escaped double quotes (`\"`) in the values and match only the opening and closing double quotes.