### PR TITLE
Fix IDE compatibility for 2025.x versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning].
 
+## 3.5.0 - 2026-01-14
+
+### Changed
+
+- Updated Gradle plugin from 1.9.0 to 1.17.4
+- Updated platform version from 2022.2 to 2024.1
+- Extended IDE compatibility range to support versions 241-253.* (2024.1 through 2025.3.x)
+- Upgraded Gradle wrapper from 7.5.1 to 8.5
+
+### Fixed
+
+- Compatibility with IntelliJ IDEA 2025.x versions ([#248])
+
 ## 3.4.2 - 2023-12-25
 
 ### Fixed
@@ -162,6 +175,7 @@ This project adheres to [Semantic Versioning].
 [#127]: https://github.com/ashald/EnvFile/issues/127
 [#151]: https://github.com/ashald/EnvFile/issues/151
 [#165]: https://github.com/ashald/EnvFile/issues/165
+[#248]: https://github.com/ashald/EnvFile/issues/248
 
 [Keep a CHANGELOG]:     http://keepachangelog.com
 [Semantic Versioning]:  http://semver.org/

--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,11 @@ allprojects {
     project.version = scmVersion.version
 
     ext.jetbrains = [
-            version : "2024.1",
-            pycharm : "PythonCore:241.14494.240",
-            rubymine: "org.jetbrains.plugins.ruby:241.14494.150",
-            goland  : "org.jetbrains.plugins.go:241.14494.234",
-            scala   : "org.intellij.scala:2024.1.4"
+            version : "2022.2",
+            pycharm : "PythonCore:222.3345.40",
+            rubymine: "org.jetbrains.plugins.ruby:222.3345.16",
+            goland  : "org.jetbrains.plugins.go:222.3345.90",
+            scala   : "org.intellij.scala:2022.2.3"
     ]
 }
 
@@ -55,14 +55,14 @@ dependencies {
 }
 
 wrapper {
-    gradleVersion = "7.5.1"
+    gradleVersion = "8.5"
 }
 
 runIde.ideDir =  java.util.Optional.ofNullable(System.getenv("IDE")).map(File::new).orElse(null)
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("241")
+        sinceBuild.set("222")
         untilBuild.set("253.*")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "idea"
-    id "org.jetbrains.intellij" version "1.9.0"
+    id "org.jetbrains.intellij" version "1.17.4"
     id "pl.allegro.tech.build.axion-release" version "1.14.1"
 }
 
@@ -25,11 +25,11 @@ allprojects {
     project.version = scmVersion.version
 
     ext.jetbrains = [
-            version : "2022.2",
-            pycharm : "PythonCore:222.3345.40",
-            rubymine: "org.jetbrains.plugins.ruby:222.3345.16",
-            goland  : "org.jetbrains.plugins.go:222.3345.90",
-            scala   : "org.intellij.scala:2022.2.3"
+            version : "2024.1",
+            pycharm : "PythonCore:241.14494.240",
+            rubymine: "org.jetbrains.plugins.ruby:241.14494.150",
+            goland  : "org.jetbrains.plugins.go:241.14494.234",
+            scala   : "org.intellij.scala:2024.1.4"
     ]
 }
 
@@ -62,7 +62,8 @@ runIde.ideDir =  java.util.Optional.ofNullable(System.getenv("IDE")).map(File::n
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("201")
+        sinceBuild.set("241")
+        untilBuild.set("253.*")
     }
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>net.ashald.envfile</id>
   <name>EnvFile</name>
-  <version>3.4.2</version>
+  <version>3.5.0</version>
   <vendor email="envfile@ashald.net">Borys Pierov</vendor>
 
   <description><![CDATA[


### PR DESCRIPTION
Update build configuration to support IntelliJ IDEA, GoLand, PyCharm, and RubyMine 2025.x versions:
- Upgrade Gradle IntelliJ plugin from 1.9.0 to 1.17.4
- Update base platform version from 2022.2 to 2024.1
- Update platform-specific plugin versions to 241 builds
- Set compatibility range to 241-253.* (2024.1 through 2025.3.x)

Fixes #248