### PR TITLE
Upgrade Gradle IntelliJ plugin to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lib/*.jar
 
 # Mac OS
 .DS_*
+.intellijPlatform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning].
 
+## 4.1.0 - 2026-01-15
+
+### Changed
+
+- Upgraded Gradle IntelliJ plugin to v2
+- Updated platform version from 2022.2 to 2022.3 as it's the minimum version for v2 of the Gradle IntelliJ plugin
+
 ## 4.0.0 - 2026-01-15
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "idea"
-    id "org.jetbrains.intellij" version "1.17.4"
+    id "org.jetbrains.intellij.platform" version "2.2.1"
     id "pl.allegro.tech.build.axion-release" version "1.14.1"
 }
 
@@ -22,32 +22,48 @@ allprojects {
     repositories {
         mavenCentral()
     }
+
     project.version = scmVersion.version
 
     ext.jetbrains = [
-            version : "2022.2",
-            pycharm : "PythonCore:222.3345.40",
-            rubymine: "org.jetbrains.plugins.ruby:222.3345.16",
-            goland  : "org.jetbrains.plugins.go:222.3345.90",
-            scala   : "org.intellij.scala:2022.2.3"
+            version : "2022.3",
+            scala   : "org.intellij.scala:2022.3.13"
     ]
 }
 
-intellij {
-    version = jetbrains.version
-    pluginName = "EnvFile"
-    sameSinceUntilBuild = false
-    updateSinceUntilBuild = false
-    downloadSources = true
-    plugins = [
-            // This doesn't make any sense as this plugin supposed to be only required on IDEA sub-module
-            // but it doesn't build without it. Suspect a validation bug in JetBrains Gradle plugin.
-            "java",
-    ]
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
+
+intellijPlatform {
+    projectName = "EnvFile"
+    buildSearchableOptions = false
+
+    pluginConfiguration {
+        name = "EnvFile"
+
+        ideaVersion {
+            sinceBuild = "223"
+            untilBuild = "253.*"
+        }
+    }
+
+    pluginVerification {
+        ides {
+            ide("IC", jetbrains.version)
+        }
+    }
+}
 
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(jetbrains.version)
+        bundledPlugin("com.intellij.java")
+        instrumentationTools()
+    }
+
     implementation project(":envfile-products-idea")
     implementation project(":envfile-products-pycharm")
     implementation project(":envfile-products-rubymine")
@@ -56,14 +72,4 @@ dependencies {
 
 wrapper {
     gradleVersion = "8.5"
-}
-
-runIde.ideDir =  java.util.Optional.ofNullable(System.getenv("IDE")).map(File::new).orElse(null)
-
-tasks {
-    patchPluginXml {
-        sinceBuild.set("222")
-        untilBuild.set("253.*")
-    }
-
 }

--- a/modules/platform/build.gradle
+++ b/modules/platform/build.gradle
@@ -1,14 +1,20 @@
 plugins {
     id "java"
-    id "org.jetbrains.intellij"
+    id "org.jetbrains.intellij.platform.module"
 }
 
-intellij {
-    version = jetbrains.version
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
 
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(jetbrains.version)
+        instrumentationTools()
+    }
+
     implementation project(":envfile-core")
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'org.apache.commons:commons-text:1.15.0'

--- a/modules/products/goland/build.gradle
+++ b/modules/products/goland/build.gradle
@@ -1,20 +1,24 @@
 plugins {
     id "java"
-    id "org.jetbrains.intellij"
+    id "org.jetbrains.intellij.platform.module"
 }
 
-intellij {
-    version = jetbrains.version
-    plugins = [
-        jetbrains.goland,
-    ]
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
 
 dependencies {
+    intellijPlatform {
+        goland(jetbrains.version)
+        bundledPlugin("org.jetbrains.plugins.go")
+        instrumentationTools()
+    }
+
     implementation project(":envfile-platform")
     implementation 'org.jetbrains:annotations:23.0.0'
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }

--- a/modules/products/idea/build.gradle
+++ b/modules/products/idea/build.gradle
@@ -1,20 +1,26 @@
 plugins {
     id "java"
-    id "org.jetbrains.intellij"
+    id "org.jetbrains.intellij.platform.module"
 }
 
-intellij {
-    version = jetbrains.version
-    plugins = [
-        "java",
-        "gradle",
-        "maven",
-        jetbrains.scala
-    ]
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
 
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(jetbrains.version)
+        bundledPlugins(
+            "com.intellij.java",
+            "com.intellij.gradle",
+            "org.jetbrains.idea.maven"
+        )
+        plugin(jetbrains.scala)
+        instrumentationTools()
+    }
+
     implementation project(":envfile-core")
     implementation project(":envfile-platform")
     implementation 'org.jetbrains:annotations:23.0.0'

--- a/modules/products/pycharm/build.gradle
+++ b/modules/products/pycharm/build.gradle
@@ -1,20 +1,24 @@
 plugins {
     id "java"
-    id "org.jetbrains.intellij"
+    id "org.jetbrains.intellij.platform.module"
 }
 
-intellij {
-    version = jetbrains.version
-    plugins = [
-        jetbrains.pycharm,
-    ]
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
 
 dependencies {
+    intellijPlatform {
+        pycharmCommunity(jetbrains.version)
+        bundledPlugin("PythonCore")
+        instrumentationTools()
+    }
+
     implementation project(":envfile-platform")
     implementation 'org.jetbrains:annotations:23.0.0'
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }

--- a/modules/products/rubymine/build.gradle
+++ b/modules/products/rubymine/build.gradle
@@ -1,20 +1,24 @@
 plugins {
     id "java"
-    id "org.jetbrains.intellij"
+    id "org.jetbrains.intellij.platform.module"
 }
 
-intellij {
-    version = jetbrains.version
-    plugins = [
-        jetbrains.rubymine,
-    ]
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
-buildSearchableOptions.enabled = false
 
 dependencies {
+    intellijPlatform {
+        rubymine(jetbrains.version)
+        bundledPlugin("org.jetbrains.plugins.ruby")
+        instrumentationTools()
+    }
+
     implementation project(":envfile-platform")
     implementation 'org.jetbrains:annotations:23.0.0'
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        maven { url = uri("https://cache-redirector.jetbrains.com/plugins.gradle.org") }
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'envfile'
 
 include (


### PR DESCRIPTION
I'm trying to run `runIde` against 2025.2 to debug Kotlin run configurations, but it doesn't work because any version higher than 2024.2 [requires](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2025.html) major version 2 of the IntelliJ Platform Gradle Plugin:

<img width="679" height="557" alt="image" src="https://github.com/user-attachments/assets/b028b03d-d1a2-4966-a28b-a0c150658437" />

This PR upgrades said plugin to v2, following the migration guide. Related documentation:

- Blog post: https://blog.jetbrains.com/platform/2024/07/intellij-platform-gradle-plugin-2-0/
- Migration guide: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html
- Sample migration that was advised for reference: https://github.com/JetBrains/intellij-platform-plugin-template/pull/458/files

Can confirm that `./gradlew verifyPlugin` passes. Ran `runIde` with a test project as well, confirming that the env vars from `.env` are loaded correctly on 2022.3:

<img width="1402" height="966" alt="Screenshot 2026-01-15 at 21 53 59" src="https://github.com/user-attachments/assets/ce525550-85b5-4e5c-960a-71bb649730ca" />

I'm happy to bump other versions in follow-up PRs, but didn't want to introduce scope creep here.