### PR TITLE
Hotfix: updated build.gradle to include latest jetbrains build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = "243"
-            untilBuild = "253.*"
+            untilBuild = "261.*"
         }
     }
 


### PR DESCRIPTION
Brief fix to include latest jetbrains build - removes incompatible plugin message.