### PR TITLE
Fix env vars not injected on WSL / remote targets (GoLand)

### DIFF
--- a/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
+++ b/modules/products/goland/src/main/java/net/ashald/envfile/products/goland/GolandRunConfigurationExtension.java
@@ -1,10 +1,13 @@
 package net.ashald.envfile.products.goland;
 
 import com.goide.execution.GoRunConfigurationBase;
+import com.goide.execution.GoRunningState;
 import com.goide.execution.extension.GoRunConfigurationExtension;
+import com.goide.util.GoExecutor;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RunnerSettings;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.SettingsEditor;
 import net.ashald.envfile.platform.EnvFileEnvironmentVariables;
 import net.ashald.envfile.platform.ui.EnvFileConfigurationEditor;
@@ -12,9 +15,12 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class GolandRunConfigurationExtension extends GoRunConfigurationExtension {
+
+    private static final Logger LOG = Logger.getInstance(GolandRunConfigurationExtension.class);
 
     @Nullable
     @Override
@@ -22,6 +28,7 @@ public class GolandRunConfigurationExtension extends GoRunConfigurationExtension
         return EnvFileConfigurationEditor.getEditorTitle();
     }
 
+    // Local runs: GoLand builds a GeneralCommandLine and invokes this legacy hook.
     @Override
     protected void patchCommandLine(
             @NotNull GoRunConfigurationBase<?> goRunConfigurationBase,
@@ -46,6 +53,55 @@ public class GolandRunConfigurationExtension extends GoRunConfigurationExtension
 
         generalCommandLine.getEnvironment().clear();
         generalCommandLine.getEnvironment().putAll(newEnv);
+    }
+
+    // Target runs (WSL / remote): GoLand bypasses the GeneralCommandLine hook above and goes through the
+    // Targets API. The executor-level hook below fires for those runs (confirmed for WSL), so we inject the
+    // EnvFile variables into the GoExecutor here. We add only the delta over the (Windows) parent environment
+    // to avoid leaking host-only variables (PATH, ProgramFiles, ...) into the target (e.g. Linux under WSL).
+    @Override
+    protected void patchExecutor(
+            @NotNull GoRunConfigurationBase<?> configuration,
+            @Nullable RunnerSettings runnerSettings,
+            @NotNull GoExecutor executor,
+            @NotNull String runnerId,
+            @NotNull GoRunningState<? extends GoRunConfigurationBase<?>> state,
+            @NotNull GoRunningState.CommandLineType commandLineType
+    )
+            throws ExecutionException
+    {
+        if (commandLineType != GoRunningState.CommandLineType.RUN) {
+            return;
+        }
+
+        Map<String, String> newEnv = new EnvFileEnvironmentVariables(
+                EnvFileConfigurationEditor.getEnvFileSetting(configuration)
+        )
+                .render(
+                        configuration.getProject(),
+                        configuration.getCustomEnvironment(),
+                        configuration.isPassParentEnvironment()
+                );
+
+        if (newEnv == null) {
+            return;
+        }
+
+        Map<String, String> parentEnv = new GeneralCommandLine()
+                .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+                .getParentEnvironment();
+
+        Map<String, String> delta = new HashMap<>();
+        for (Map.Entry<String, String> entry : newEnv.entrySet()) {
+            if (!entry.getValue().equals(parentEnv.get(entry.getKey()))) {
+                delta.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        executor.withUserDefinedEnvironment(delta);
+
+        LOG.debug("EnvFile: injected " + delta.size()
+                + " variable(s) into GoExecutor for target run: " + delta.keySet());
     }
 
     @Override


### PR DESCRIPTION
### Problem

Fixes #258. On WSL (and other remote targets) EnvFile variables never reach the Go process.

### Root cause

For a local run GoLand builds a `GeneralCommandLine` and calls the legacy
`GoRunConfigurationExtension.patchCommandLine(..., GeneralCommandLine, ...)` hook that EnvFile
overrides. For a **target** run (WSL, SSH remote) GoLand goes through the Targets API and builds a
`TargetedCommandLineBuilder` instead — the legacy hook is **never invoked**, so EnvFile injects nothing.

Verified on GoLand 2025.2.6.1: with logging in all three `GoRunConfigurationExtension` hooks, a WSL run
fires only `patchExecutor` and the target `patchCommandLine(TargetedCommandLineBuilder, ...)`; the legacy
`patchCommandLine(GeneralCommandLine, ...)` does not fire.

### Fix

Override the executor-level `patchExecutor` hook (which fires for both local and target runs) and inject the
resolved variables via `GoExecutor#withUserDefinedEnvironment` — the same channel the native run-config
*Environment* field uses, which is known to reach the target.

To avoid leaking host-only variables (`PATH`, `ProgramFiles`, `windir`, ...) into the target environment
(e.g. Linux under WSL, where a Windows `PATH` would be harmful), only the **delta over the parent/host
environment** is injected. Injection is limited to `CommandLineType.RUN`.

The local path is left untouched: the legacy `patchCommandLine(GeneralCommandLine)` still runs and, on local
runs, overwrites the command-line environment as before — so local behaviour is unchanged.

### Scope

This addresses the **GoLand** module only. #258 also reports the same class of problem for PyCharm over SSH;
that would need an analogous change in the respective product module and is out of scope here.

### Testing

- GoLand 2025.2.6.1, WSL2 (Ubuntu), real Go microservice with a `.env`: variables now reach the process and
  the service starts; injected set contains the service variables and none of the Windows host variables.
- Local (non-WSL) run: no regression, variables load as before.
